### PR TITLE
Replacing dates with names of developers of extensions

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,7 +43,9 @@
       {% endif %} {% endfor %} {% if page.url == a %}
       <h1>{{ page.title | upcase}}</h1>
       {% unless page.describe %}
-      <div class="ge">{{ page.date | date: "%b %-d, %Y" }}</div>
+      <div class="ge">{% if page.developer %}
+         Developed by {{ page.developer }}
+         {% endif %}</div>
       {% else %}
       <div class="ge">{{ page.describe }}</div>
       {% endunless %}
@@ -143,7 +145,7 @@
    <ul>
    <li class="post-list"><a class="waves-effect post-list black-text" data-tooltip="{{#date}}{{pubdate}}{{/date}}" href="{% endraw %}{{ site.baseurl }}{% raw %}{{url}}">{{title}}</a></li>
    </ul>
-    
+
   {{/entries}}
   </div>
 </script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,5 +1,5 @@
---- 
-layout: default 
+---
+layout: default
 ---
 <br>
 
@@ -17,7 +17,9 @@ layout: default
                 {%else%}
 <img  data-position="bottom" data-delay="50" data-tooltip="{{ site.defaultAuthor }}"  class="right tooltipped" style="width: 18px;" src="{{ site.defaultAuthorImage }}" alt="">
                 {% endif %}
-                   {{ post.date | date: "%b %-d, %Y" }}
+                %}{% if post.developer %}
+                   Developed by {{ post.developer }}
+                   {% endif %}
                    </p>
                 <hr>
                 <div id="postsContent">

--- a/_posts/2017-04-23-colours-extension.md
+++ b/_posts/2017-04-23-colours-extension.md
@@ -4,9 +4,10 @@ title: Colours Extension
 categories: Design
 tags: Helios Colours HEX RGB
 toc: true
+developer: Helios
 ---
 
-Developed by Helios, this extension allows you to convert #HEX colours to (R G B) and vice versa. It also allows you to lighten, darken and mix colours. 
+Developed by Helios, this extension allows you to convert #HEX colours to (R G B) and vice versa. It also allows you to lighten, darken and mix colours.
 
 <!-- more -->
 
@@ -20,10 +21,10 @@ Developed by Helios, this extension allows you to convert #HEX colours to (R G B
 | License | LINK|
 
 <p hidden id="copyTarget">http://community.thunkable.com/uploads/default/original/2X/e/e754019115c3749479777af7a952fbf347e06927.aix</p>
- 
+
 ## Thunkable Community
 
->If you have any questions about the Colours Extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/colours-extension/2513?u=domhnall) where you'll find lots of amazing people who are happy to help you out. 
+>If you have any questions about the Colours Extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/colours-extension/2513?u=domhnall) where you'll find lots of amazing people who are happy to help you out.
 
 ## Installation
 
@@ -34,7 +35,7 @@ You can either follow all the steps as shown in the animation below or you can a
 
 ### HexToRGB {#h2r}
 
-The <span class="block procedure">Colours1.HexToRGB</span> block takes a #HEX colour and converts it into a lisp list in the format (R G B). 
+The <span class="block procedure">Colours1.HexToRGB</span> block takes a #HEX colour and converts it into a lisp list in the format (R G B).
 
 ![h2r](http://domhnallohanlon.com/thunkable_extensions/assets/post_assets/colours_extension/colours_h2r.png)
 
@@ -50,11 +51,11 @@ The <span class="block procedure">Colours1.RGBToHex</span> block takes a lisp li
 
 ### Lighten & Darken {#landd}
 
-Both the lighten and darken blocks require two input aruments. 
+Both the lighten and darken blocks require two input aruments.
 The **colour** input expects a list in the form (R G B), rather than an integer as an input.
 The **amount** input expects an input anywhere between 0 and 1.
 
-The lighten and darken blocks return a (R G B) list, so if you want to apply this as a text or background colour somewhere in your app make sure you pass it through a <span class="block split">make color</span> block, which you can find in the colours category of blocks, but you have to remove the <span class="block list">make a list</span> block first. 
+The lighten and darken blocks return a (R G B) list, so if you want to apply this as a text or background colour somewhere in your app make sure you pass it through a <span class="block split">make color</span> block, which you can find in the colours category of blocks, but you have to remove the <span class="block list">make a list</span> block first.
 
 Here are two basic examples of using the lighten and darken procedures.
 ![darken](http://domhnallohanlon.com/thunkable_extensions/assets/post_assets/colours_extension/colours_darken.png)
@@ -64,7 +65,7 @@ Here are two basic examples of using the lighten and darken procedures.
 
 In keeping with the previous blocks, the inputs for this block, <code>ColourA</code> and <code>ColourB</code> are (R G B) lists, and the <code>amount</code> argument accepts a number anywhere between 0 and 1.
 
-The example below shows how use either a default colour or a custom colour as an input and mix them together. 
+The example below shows how use either a default colour or a custom colour as an input and mix them together.
 
 Again, the return type from this block is a (R G B) list so don't forget to pass it through a <span class="block split">make color</span> block if you want to use it to assign a colour to a component in your design.
 
@@ -73,5 +74,3 @@ Again, the return type from this block is a (R G B) list so don't forget to pass
 ## Download
 
 The full extension can be dowloaded from the [Thunkable community](http://community.thunkable.com/t/colours-extension/2513?u=helios), along with Helios' documentation and sample app.
-
-

--- a/_posts/2017-04-23-free-iap.md
+++ b/_posts/2017-04-23-free-iap.md
@@ -3,6 +3,7 @@ layout: post
 title: Free InAppPurchases
 categories: Monetisation
 tags: Pavitra IAP Billing
+developer: Pavitra
 ---
 
 This extension allows your users to buy goods directly from your app using Google Play's Billing service.
@@ -12,7 +13,7 @@ This extension allows your users to buy goods directly from your app using Googl
 ## Overview
 
 | Extension Developer | LINK |
-| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK| 
+| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK|
 | Get the .aix | <a href="http://community.thunkable.com/t/colours-extension/2513?u=helios" hidden>Manual Download</a> LINK|
 | Click-to-Copy Link | <a href="#" id="copyButton" hidden>com.vishwas.Colours.aix</a> LINK
 | Donate to Developer | LINK |
@@ -22,7 +23,7 @@ This extension allows your users to buy goods directly from your app using Googl
 
 ## Thunkable Community
 
->If you have any questions about this extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/free-iap-extension/2082?u=domhnall) where you'll find lots of amazing people who are happy to help you out. 
+>If you have any questions about this extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/free-iap-extension/2082?u=domhnall) where you'll find lots of amazing people who are happy to help you out.
 
 
 

--- a/_posts/2017-04-23-image-editor-extension.md
+++ b/_posts/2017-04-23-image-editor-extension.md
@@ -4,6 +4,7 @@ categories: Design
 title: Image Editor Extension
 <!-- image: /assets/images/demo0.jpg -->
 tags: NMDApps Editor
+developer: Mika
 ---
 
 Developed by Thunkable Community Member, Mika, this extension allows users to set brightness, tints, watermarks, filters, and much, much more to images from their apps.
@@ -14,7 +15,7 @@ Developed by Thunkable Community Member, Mika, this extension allows users to se
 ## Overview
 
 | Extension Developer | LINK |
-| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK| 
+| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK|
 | Get the .aix | <a href="http://community.thunkable.com/t/colours-extension/2513?u=helios" hidden>Manual Download</a> LINK|
 | Click-to-Copy Link | <a href="#" id="copyButton" hidden>com.vishwas.Colours.aix</a> LINK
 | Donate to Developer | LINK |
@@ -24,7 +25,7 @@ Developed by Thunkable Community Member, Mika, this extension allows users to se
 
 ## Thunkable Community
 
-If you have any questions about this exetnsio then head on over to the [Thunkable Community](https://community.thunkable.com/t/image-editor-extension-no-internet-connection-required/2495?u=domhnall) where you'll find lots of amazing people who are happy to help you out. 
+If you have any questions about this exetnsio then head on over to the [Thunkable Community](https://community.thunkable.com/t/image-editor-extension-no-internet-connection-required/2495?u=domhnall) where you'll find lots of amazing people who are happy to help you out.
 
 ### Download
 

--- a/_posts/2017-04-30-dialogs-extension.md
+++ b/_posts/2017-04-30-dialogs-extension.md
@@ -4,6 +4,7 @@ title: Dialogs Extension
 categories: Design
 author: Conor
 tags: Helios Dialogs HEX RGB
+developer: Helios
 ---
 
 Developed by Helios, this extension allows you to show progress bars, radio list pickers, checkboxes, and more in a dialog box.
@@ -13,7 +14,7 @@ Developed by Helios, this extension allows you to show progress bars, radio list
 ## Overview
 
 | Extension Developer | <a href="http://community.thunkable.com/users/helios/">Helios</a> |
-| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK| 
+| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK|
 | Get the .aix | <a href="https://community.thunkable.com/t/releasing-the-dialogs-extension/2574/116?u=helios">Manual Download</a>|
 | Click-to-Copy Link | <a href="#" id="copyButton">com.vishwas.Dialogs.aix</a>
 | Donate to Developer | N/A |
@@ -23,7 +24,7 @@ Developed by Helios, this extension allows you to show progress bars, radio list
 
 ## Thunkable Community
 
->If you have any questions about this extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/releasing-the-dialogs-extension/2574?u=domhnall) where you'll find lots of amazing people who are happy to help you out. 
+>If you have any questions about this extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/releasing-the-dialogs-extension/2574?u=domhnall) where you'll find lots of amazing people who are happy to help you out.
 
 
 

--- a/_posts/2017-05-01-bluetoothplus-extension.md
+++ b/_posts/2017-05-01-bluetoothplus-extension.md
@@ -4,6 +4,7 @@ title: BluetoothPlus Extension
 date: 2017-05-01
 categories: Bluetooth
 tags: Sander bluetooth
+developer: Sander
 ---
 
 Interact with other Bluetooth devices by using this extension by Thunkable community member, Sander.
@@ -14,7 +15,7 @@ Click to read more.
 ## Overview
 
 | Extension Developer | <a href="http://www.sanderjochems.nl/appinventor/extensions/1/bluetoothplus" target="_blank">Sander Jochems</a> |
-| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK| 
+| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK|
 | Get the .aix | <a href="http://community.thunkable.com/t/colours-extension/2513?u=helios" hidden>Manual Download</a> LINK|
 | Click-to-Copy Link | <a href="#" id="copyButton" hidden>com.vishwas.Colours.aix</a> LINK
 | Donate to Developer | <a href="https://play.google.com/store/apps/details?id=com.thunkable.android.sander542jochems.Donate" target="_blank"><img src="https://img.shields.io/badge/Donate-Google_Play-ee6e73.svg?style=flat-square"></a> |
@@ -25,7 +26,7 @@ Click to read more.
 
 ## Thunkable Community
 
-If you have any questions about this exetnsio then head on over to the [Thunkable Community](http://community.thunkable.com/t/bluetoothplus-extension/2706?u=domhnall) where you'll find lots of amazing people who are happy to help you out. 
+If you have any questions about this exetnsio then head on over to the [Thunkable Community](http://community.thunkable.com/t/bluetoothplus-extension/2706?u=domhnall) where you'll find lots of amazing people who are happy to help you out.
 
 
 ## Blocks
@@ -74,4 +75,3 @@ Check if a Bluetooth UserMacAddress is valid.
 Post written by:
 <a href="https://community.thunkable.com/u/domhnall">Domhnall</a>
 <br>
-

--- a/_posts/2017-05-02-arduino-extension.md
+++ b/_posts/2017-05-02-arduino-extension.md
@@ -4,6 +4,7 @@ title: Arduino USB Serial Extension
 date: 2017-05-02
 categories: Tools
 tags: Pavitra Arduino USB Serial
+developer: Pavitra
 ---
 
 Using this extension you can create a serial connection via USB between your phone and an Arduino
@@ -12,7 +13,7 @@ Using this extension you can create a serial connection via USB between your pho
 ## Overview
 
 | Extension Developer | LINK |
-| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK| 
+| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK|
 | Get the .aix | <a href="http://community.thunkable.com/t/colours-extension/2513?u=helios" hidden>Manual Download</a> LINK|
 | Click-to-Copy Link | <a href="#" id="copyButton" hidden>com.vishwas.Colours.aix</a> LINK
 | Donate to Developer | LINK |
@@ -23,7 +24,7 @@ Using this extension you can create a serial connection via USB between your pho
 
 ## Thunkable Community
 
->If you have any questions about this extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/test-arduino-usb-serial-extension/2624?u=domhnall) where you'll find lots of amazing people who are happy to help you out. 
+>If you have any questions about this extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/test-arduino-usb-serial-extension/2624?u=domhnall) where you'll find lots of amazing people who are happy to help you out.
 
 
 ## Download
@@ -58,4 +59,3 @@ You can open and close the connection with the open and close blocks.
 
 ### Misc
 ![Arduino Object](http://domhnallohanlon.com/thunkable_extensions/assets/post_assets/arduino_extension/arduino1.png)
-

--- a/_posts/2017-05-11-chart-extension.md
+++ b/_posts/2017-05-11-chart-extension.md
@@ -4,6 +4,7 @@ title: Chart Maker Extension
 categories: Design
 author: Sivagiri
 tags: Google Chart Maker
+developer: Kate Manning and Emily Kager
 ---
 
 The Chart Maker extension,developed by Kate Manning and Emily Kager allows us to create charts using the [Google Charts](https://developers.google.com/chart). The charts generated can be displayed using a [_Web Viewer_.](http://thunkable.com/reference/components/user_interface.html)
@@ -22,19 +23,19 @@ The Chart Maker extension,developed by Kate Manning and Emily Kager allows us to
 
 
 ### How Google Charts work
- 
+
 Google Charts require the data to be in the form of table with rows and columns.
 This extension turns the input provided into a table to generate a chart
 
 
 Each column should have a label and type of data which will be entered in it . Each chart requires different format of the table to be followed. The structure of tables of different charts are discussed in the next section.
 
-# Blocks 
+# Blocks
 
 
 ### DrawPieChart
 
-The "DrawPieChart" block is used to create a Pie Chart. [Here](https://eagereyes.org/techniques/pie-charts) is a great article that might help in understanding pie charts. 
+The "DrawPieChart" block is used to create a Pie Chart. [Here](https://eagereyes.org/techniques/pie-charts) is a great article that might help in understanding pie charts.
 
 The following example demonstrates the usage of this block :
 

--- a/_posts/2017-05-14-fab-extension.md
+++ b/_posts/2017-05-14-fab-extension.md
@@ -3,7 +3,8 @@ layout: post
 title: FAB Extension
 date: 2017-05-14
 categories: Design
-tags: Pavitra Sander FAB 
+tags: Pavitra Sander FAB
+developer: Pavitra and Sander
 ---
 
 The Floating Action Button, or FAB, is one of the most distinctive design features of Material Design, and with this extension you can easily add one to your app.  
@@ -13,9 +14,9 @@ The Floating Action Button, or FAB, is one of the most distinctive design featur
 ## Overview
 
 | Extension Developer | <a href="https://community.thunkable.com/u/pavi2410/" target="_blank">Pavitra</a> and <a href="http://www.sanderjochems.nl/appinventor/extension/4/floatingactionbutton" target="_blank">Sander</a> |
-| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/fab/fab_starter_template.asc" class="flat_btn" target="_blank"> Open in Thunkable</a>| 
+| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/fab/fab_starter_template.asc" class="flat_btn" target="_blank"> Open in Thunkable</a>|
 | Get the .aix | <a href="https://community.thunkable.com/uploads/default/original/2X/5/594cd84a60e4d7dce28de3af3eb889a8ac47a2f7.aix" >Manual Download</a>|
-| Click-to-Copy Link | <a href="#" id="copyButton">com.sander0542_pavitra.FAB.aix</a> 
+| Click-to-Copy Link | <a href="#" id="copyButton">com.sander0542_pavitra.FAB.aix</a>
 | Donate to Developers | N/A |
 | License | N/A </a>|
 
@@ -23,7 +24,7 @@ The Floating Action Button, or FAB, is one of the most distinctive design featur
 
 ## Thunkable Community
 
->If you have any questions about the FAB Extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/fab-extension-material-ui-feature/3488?u=domhnall) where you'll find lots of amazing people who are happy to help you out. 
+>If you have any questions about the FAB Extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/fab-extension-material-ui-feature/3488?u=domhnall) where you'll find lots of amazing people who are happy to help you out.
 
 ## Installation
 

--- a/_posts/2017-05-15-network-tools-extension.md
+++ b/_posts/2017-05-15-network-tools-extension.md
@@ -3,7 +3,8 @@ layout: post
 title: Network Tools Extension
 date: 2017-05-15
 categories: Tools
-tags: AndresCotes 
+tags: AndresCotes
+developer: Andres Cotes
 ---
 
 The Network Tools extension by Andres lets you find out your IP address in IPv4 or IPv6 format.
@@ -14,9 +15,9 @@ The Network Tools extension by Andres lets you find out your IP address in IPv4 
 ## Overview
 
 | Extension Developer | <a href="https://community.thunkable.com/u/andres_cotes/summary" target="_blank">Andres Cotes</a> |
-| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/network_tools/network_tools_starter_template.asc" class="flat_btn" target="_blank"> Open in Thunkable</a>| 
+| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/network_tools/network_tools_starter_template.asc" class="flat_btn" target="_blank"> Open in Thunkable</a>|
 | Get the .aix | <a href="https://groups.google.com/group/mitappinventortest/attach/49b8dce2ca1a3/co.com.dendritas.NetworkTools.aix?part=0.1&authuser=1" >Manual Download</a>|
-| Click-to-Copy Link | <a href="#" id="copyButton">co.com.dendritas.NetworkTools.aix</a> 
+| Click-to-Copy Link | <a href="#" id="copyButton">co.com.dendritas.NetworkTools.aix</a>
 | Donate to Developer | N/A |
 | License | <a href="https://en.wikipedia.org/wiki/MIT_License" target="_blank">MIT</a>|
 
@@ -28,9 +29,9 @@ This simple extension contains just two blocks, it's very easy to use.
 
 ### Get IP Address
 
-It does what it says on the tin really. This block returns the phone's IP address in IPv4 or IPv6 format. 
+It does what it says on the tin really. This block returns the phone's IP address in IPv4 or IPv6 format.
 
-The input parameter, `useIPv4` takes a logic value, either True or False. 
+The input parameter, `useIPv4` takes a logic value, either True or False.
 
 ![GetIPAddress](http://domhnallohanlon.com/thunkable_extensions/assets/post_assets/network_tools_extension/GetIPAddress.png)
 

--- a/_posts/2017-05-16-special-tools-extension.md
+++ b/_posts/2017-05-16-special-tools-extension.md
@@ -3,7 +3,8 @@ layout: post
 title: Special Tools Extension
 date: 2017-05-16
 categories: Tools
-tags: NMDApps 
+tags: NMDApps
+developer: Mika
 ---
 
 The Special Tools extension by Mika lets you find out information about your users device. What size screen do they have, where are they from, what language are they using? All these questions, and more can answered with this extension.
@@ -15,7 +16,7 @@ The Special Tools extension by Mika lets you find out information about your use
 ## Overview
 
 | Extension Developer | <a href="https://nmd-apps.jimdo.com/extensions/nmd-extensions/#4" target="_blank">NMD Apps</a> |
-| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK| 
+| Clone Starter .aia | <a href="http://app.thunkable.com/?repo=raw.githubusercontent.com/domhnallohanlon/thunkable_extensions/gh-pages/assets/aia_repo/colours_extension_starter_template.asc" class="flat_btn" target="_blank" hidden> Open in Thunkable</a> LINK|
 | Get the .aix | <a href="https://sourceforge.net/projects/released/files/com.NMD.SpecialTools.aix/download" >Source Forge Download</a>|
 | Click-to-Copy Link | <a href="#" id="copyButton" hidden>com.vishwas.Colours.aix</a> Not supported at this time
 | Donate to Developer | <a href="https://goo.gl/Q5b0es" target="_blank"><input type="image" src="http://domhnallohanlon.com/thunkable_extensions/assets/images/donate_pp.png" width="94px" height="20px"></a>|
@@ -31,7 +32,7 @@ The Special Tools extension by Mika lets you find out information about your use
 
 ## Thunkable Community
 
->If you have any questions about this extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/special-tools-extension/1609?u=domhnall) where you'll find lots of amazing people who are happy to help you out. 
+>If you have any questions about this extension then head on over to the [Thunkable Community](https://community.thunkable.com/t/special-tools-extension/1609?u=domhnall) where you'll find lots of amazing people who are happy to help you out.
 
 
 ## Blocks

--- a/_posts/2017-05-19-qr-code-extension.md
+++ b/_posts/2017-05-19-qr-code-extension.md
@@ -5,6 +5,7 @@ date: 2017-05-19
 categories: Tools
 tags: NMDApps QRcode
 author: Sivagiri
+developer: Mika
 
 ---
 


### PR DESCRIPTION
The dates shown in the cards in  home page and headers of posts are now replaced with 
``` Developed by DEVELOPER_NAME ```.
In the new posts , ``` developer: DEVELOPER_NAME ``` must be added in the front matter at the top of each post.